### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Of course, MerkadoPago isn't perfect and I created it for my own projects, but t
 ```kotlin
 repositories {
     ...
-    maven("https://repo.perfectdreams.net/")
+    maven{ url 'https://repo.perfectdreams.net/' }
 }
 
 dependencies {


### PR DESCRIPTION
Proposal to change due the "incorrect" way to use a repository. The current warning https://prnt.sc/tjrrud shows when you try to use the indication in readme file.